### PR TITLE
ci: Fail the build if modified files are found

### DIFF
--- a/.github/workflows/build.ci.yml
+++ b/.github/workflows/build.ci.yml
@@ -17,3 +17,4 @@ jobs:
           node-version: '12'
       - run: npm ci
       - run: npm run build
+      - run: git diff --quiet

--- a/.github/workflows/deploy.ci.yml
+++ b/.github/workflows/deploy.ci.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: '12'
       - run: npm ci
       - run: npm run build
+      - run: git diff --quiet
       - run: git config user.email "support+actions@github.com"
       - run: git config user.name "github-actions-bot"
       - run: git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/ramblenride/motorcycle-service-db.git


### PR DESCRIPTION
Add `git diff --quiet` to the scripts. It returns non-zero when modified files are found. This should stop the build.

Closing #3